### PR TITLE
graph.json: rexexp to enum

### DIFF
--- a/spec/schemas/graph.json
+++ b/spec/schemas/graph.json
@@ -36,7 +36,7 @@
     "dsClass": {
       "description": "A keyword describing the main interpretation of the graph",
       "type": "string",
-      "pattern": "^(list)|(tree)|(graph)$"
+      "enum": ["list", "tree", "graph"]
     },
     "dsSubClass": {
       "description": "A free keyword descriping the detailed interpretation of the graph.",


### PR DESCRIPTION
graph.dsClass is basically a string of three predefined choices.
Therefore let's not use a "pattern" option with regexp, but an enum
instead.